### PR TITLE
Fully qualify `puppet` command for console refresh

### DIFF
--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -38,9 +38,9 @@ end
 
 def refresh_environment(environment)
   auth_info = {
-    "ca_certificate_path" => `puppet config print localcacert`.strip,
-    "certificate_path"    => `puppet config print hostcert`.strip,
-    "private_key_path"    => `puppet config print hostprivkey`.strip,    
+    "ca_certificate_path" => `/opt/puppetlabs/bin/puppet config print localcacert`.strip,
+    "certificate_path"    => `/opt/puppetlabs/bin/puppet config print hostcert`.strip,
+    "private_key_path"    => `/opt/puppetlabs/bin/puppet config print hostprivkey`.strip,
     "read_timeout"        => 90
   }
   classifier_url = "https://#{Puppet[:server]}:4433/classifier-api"


### PR DESCRIPTION
Without this commit, the method that refreshes the Puppet Enterprise
Console was calling out to the Puppet binary without fully qualifying
the command. This was resulting in a failure of the task as the command
was not returning properly.

This commit fully qualifies the usage of the `puppet` binary
(/opt/puppetlabs/bin/puppet) to ensure that the proper binary is used
and will return successfully.